### PR TITLE
Registry Check path updated for OBS Studio 25.0.8

### DIFF
--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -42,8 +42,8 @@ RequestExecutionLevel admin
 !insertmacro MUI_RESERVEFILE_LANGDLL
 
 Function PreReqCheck
-  ; Check to see if OBS is Installed
-  ReadRegStr $0 HKLM "Software\Open Broadcaster Software" ""
+  ; Check to see if OBS is Installed;
+  ReadRegStr $0 HKLM "Software\OBS Studio" ""
   
   ${If} $0 == "";
     MessageBox MB_OK|MB_ICONSTOP "${APPNAME} requires that Open Broadcaster Software be already installed."


### PR DESCRIPTION
OBS Studio 25.0.8 uses the registry path HKLM\Software\OBS Studio; hence this update prevents false negatives.
![image](https://user-images.githubusercontent.com/1406424/82505620-2bf98480-9acc-11ea-8508-99930beb46bd.png)
